### PR TITLE
Fixed bug in WebcamDialog

### DIFF
--- a/src/Components/WebcamCapture.js
+++ b/src/Components/WebcamCapture.js
@@ -27,7 +27,7 @@ export default class WebcamModal extends React.Component {
         <Button variant="outlined" color="primary" onClick={this.handleClickOpen}>
           Get Screenshot
         </Button>
-        <Dialog> 
+        <Dialog 
           open={this.state.open}
           onClose={this.handleClose}
           aria-labelledby="alert-dialog-title"


### PR DESCRIPTION
There was an extra ">" which prevented the Dialog from opening.